### PR TITLE
Add SonarQube scanning to CI

### DIFF
--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -1,0 +1,26 @@
+name: SonarQube Scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarqube:
+    name: SonarQube Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v7
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
+            -Dsonar.qualitygate.wait=true


### PR DESCRIPTION
Source-only scan (no build) -- this mod references local game/Steam DLLs by absolute path that don't exist on a CI runner, so a real dotnet build isn't possible here.